### PR TITLE
go 1.20 -> 1.22.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/traPtitech/naro-template-backend
 
-go 1.20
+go 1.22.1


### PR DESCRIPTION
go 1.21 以降はパッチバージョンを含めないと`toolchain`ディレクティブが自動で追加されるようになっているそうです

`toolchain`まわりは今後パッチバージョンなしでも大丈夫なように戻される可能性があるとのことですが、今はとりあえずこの形で

https://zenn.dev/haruyama480/articles/7e3b00bfad69ae