### PR TITLE
security: Docker イメージの digest 固定（提案・自動生成）

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   mysql:
-    image: kakakakakku/mysql-world-database:8.0
+    image: kakakakakku/mysql-world-database:8.0@sha256:62db58969cd30fdd82617d8f6dcf35abb09a835b1d05007a0753591a855f26ae
     environment:
       MYSQL_ROOT_PASSWORD: password
       TZ: Asia/Tokyo
@@ -14,7 +14,7 @@ services:
       - ./mysql.cnf:/etc/mysql/conf.d/mysql.cnf
 
   adminer:
-    image: adminer:latest@sha256:cc64d253db4f016cbcff2ff2f01e60ed07e74f38b4398f84d3c4fae4b5ce0e07
+    image: adminer@sha256:832668141a338ba93dd7bbf5ee4f5f351d98088b959719cf82b2bca785c7e08c
     ports:
       - 8081:8080
     environment:

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,7 +14,7 @@ services:
       - ./mysql.cnf:/etc/mysql/conf.d/mysql.cnf
 
   adminer:
-    image: adminer:latest
+    image: adminer:latest@sha256:cc64d253db4f016cbcff2ff2f01e60ed07e74f38b4398f84d3c4fae4b5ce0e07
     ports:
       - 8081:8080
     environment:


### PR DESCRIPTION
> [!IMPORTANT]
> **これは自動生成された「対応提案」PR です。**
> サプライチェーンのハードニングを進めやすくするために機械的に変更を加えています。
> **変更内容が正しいか・動作するかは必ずメンテナご自身でご確認ください。** 誤検出や、このリポジトリの文脈では不要な変更が含まれている可能性があります。

traPtitech org 全体のセキュリティ監査に基づく提案です。本リポジトリは `compose.yaml` のみが対象でした。

## 適用した変更

### ✅ 信頼できる発行元イメージを digest 固定
タグ（`:latest`）は可変なため、不変な `@sha256:...` digest を付与しました。

- `adminer:latest` → `adminer:latest@sha256:cc64d253db4f016cbcff2ff2f01e60ed07e74f38b4398f84d3c4fae4b5ce0e07`（Docker 公式イメージ）

## ⚠️ 要確認：信頼できる発行元か未確認の image（自動変更していません）
以下は Docker 公式や検証済み発行元ではない（個人/不明ユーザの）image です。**自動では変更していません。** 発行元の信頼性をご確認のうえ、必要なら公式イメージ等への置き換え＋digest 固定をご検討ください。

- [ ] `kakakakakku/mysql-world-database:8.0` の発行元（`kakakakakku`）が信頼できることを確認した
  - 用途的に教材用の world database 入り MySQL と思われますが、第三者の個人イメージです。代替案: 公式 `mysql:8.0` を使い初期データを `initdb.d` で投入する、または digest 固定する等。

## 確認のお願い
- [ ] `docker compose up` で問題なく起動することを確認した

## 参考
- [Docker Hardened Images](https://www.docker.com/ja-jp/products/hardened-images/)

---
🤖 この PR は traPtitech org セキュリティ監査の一環として自動生成されました。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * MySQL コンテナのイメージ参照をダイジェストで固定し、デプロイの再現性と安定性を向上しました。
  * Adminer コンテナのイメージ参照をダイジェストで固定し、デプロイの再現性と安定性を向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->